### PR TITLE
17 implement index show options

### DIFF
--- a/src/main/java/HTTPServer/HTTPRequestHandler.java
+++ b/src/main/java/HTTPServer/HTTPRequestHandler.java
@@ -64,7 +64,7 @@ public class HTTPRequestHandler {
 
     private byte[] handleDirectory(File currentFile, Map request) throws IOException {
         File index = new File(currentFile.getPath().concat("/index.html"));
-        if (request.get("path").equals("/") && index.exists() && settings.autoIndex) {
+        if (index.exists() && settings.autoIndex) {
             return writeFileContents(index);
         } else {
             return generateDirectoryResponse(currentFile, request);
@@ -72,7 +72,12 @@ public class HTTPRequestHandler {
     }
 
     private String findRoute(File currentFile) {
-        return currentFile.getPath().replaceFirst(settings.root.getPath(), "");
+        String route = currentFile.getPath().replaceFirst(settings.root.getPath(), "");
+        if (route.isEmpty()) {
+            return "/";
+        } else {
+            return route;
+        }
     }
 
     private byte[] generateDirectoryResponse(File currentFile, Map parsedRequest) throws IOException {

--- a/src/main/java/HTTPServer/HTTPRequestHandler.java
+++ b/src/main/java/HTTPServer/HTTPRequestHandler.java
@@ -64,7 +64,7 @@ public class HTTPRequestHandler {
 
     private byte[] handleDirectory(File currentFile, Map request) throws IOException {
         File index = new File(currentFile.getPath().concat("/index.html"));
-        if (request.get("path").equals("/") && index.exists()) {
+        if (request.get("path").equals("/") && index.exists() && settings.autoIndex) {
             return writeFileContents(index);
         } else {
             return generateDirectoryResponse(currentFile, request);

--- a/src/main/java/HTTPServer/Setup.java
+++ b/src/main/java/HTTPServer/Setup.java
@@ -6,27 +6,39 @@ import java.io.File;
  * Created by jphoenix on 8/8/16.
  */
 public class Setup {
+    public String[] args;
     public File root;
     public int port;
+    public boolean autoIndex;
 
     public Setup(String[] args) {
-        assignPort(args);
-        assignRoot(args);
+        this.args = args;
+        this.port = assignPort(args);
+        this.root = assignRoot(args);
+        this.autoIndex = assignAutoIndex(args);
     }
 
-    private void assignPort(String[] args) {
-        if (flagFound(args, "-p")) {
-            this.port = Integer.parseInt(argAfterFlag(args, "-p"));
+    private boolean assignAutoIndex(String[] args) {
+        if (flagFound(args, "-ai")) {
+            return true;
         } else {
-            this.port = 5000;
+            return false;
         }
     }
 
-    private void assignRoot(String[] args) {
-        if (flagFound(args, "-d")) {
-            this.root = new File(stripEntry(argAfterFlag(args, "-d")));
+    private int assignPort(String[] args) {
+        if (flagFound(args, "-p")) {
+            return Integer.parseInt(argAfterFlag(args, "-p"));
         } else {
-            this.root = new File("public");
+            return 5000;
+        }
+    }
+
+    private File assignRoot(String[] args) {
+        if (flagFound(args, "-d")) {
+            return new File(stripEntry(argAfterFlag(args, "-d")));
+        } else {
+            return new File("public");
         }
     }
 

--- a/src/test/java/HTTPRequestHandlerTest.java
+++ b/src/test/java/HTTPRequestHandlerTest.java
@@ -1,6 +1,6 @@
 import HTTPServer.HTTPRequestHandler;
+import HTTPServer.Setup;
 import junit.framework.TestCase;
-import org.junit.Ignore;
 
 import java.io.*;
 
@@ -10,7 +10,12 @@ import java.io.*;
 public class HTTPRequestHandlerTest extends TestCase {
     public void testItHandlesASimpleRequest() throws Exception {
         InputStream request = new ByteArrayInputStream("GET / HTTP/1.1".getBytes());
-        HTTPRequestHandler handler = new HTTPRequestHandler("public");
+        String[] args = new String[3];
+        args[0] = "-d";
+        args[1] = "public";
+        args[2] = "-ai";
+        Setup settings = new Setup(args);
+        HTTPRequestHandler handler = new HTTPRequestHandler(settings);
 
         byte[] response = handler.handle(request);
 
@@ -20,13 +25,16 @@ public class HTTPRequestHandlerTest extends TestCase {
 
     public void testItReadsADirectoryStructureIfNoIndexPresent() throws Exception {
         InputStream request = new ByteArrayInputStream("GET / HTTP/1.1".getBytes());
-        HTTPRequestHandler handler = new HTTPRequestHandler("otherPublic");
+        HTTPRequestHandler handler = new HTTPRequestHandler("public");
 
         byte[] response = handler.handle(request);
 
         String innerHtml = "" +
-                createLink("/fakeDirectory", "fakeDirectory") +
-                createLink("/thing.txt", "thing.txt");
+                createLink("/brians", "brians") +
+                createLink("/games", "games") +
+                createLink("/geoffs-sweet-site", "geoffs-sweet-site") +
+                createLink("/images", "images") +
+                createLink("/index.html", "index.html");
         String basicResponse = basicResponse("Content-Type: text/html\r\n\r\n", wrapHtml(innerHtml));
         assertEquals(basicResponse, new String(response, "UTF-8"));
     }
@@ -177,6 +185,12 @@ public class HTTPRequestHandlerTest extends TestCase {
 
         assertEquals("HTTP/1.1 404 NOT FOUND\r\n\r\n", new String(response, "UTF-8"));
     }
+
+//    public void testItServesUpAnIndexOnDirectoryWhenPassedFlag() throws Exception {
+//        InputStream request = new ByteArrayInputStream("GET / HTTP/1.1".getBytes());
+//        HTTPRequestHandler handler = new HTTPRequestHandler("public", true);
+//
+//    }
 
     private String basicResponse(String headers, String html) {
         return "HTTP/1.1 200 OK\r\n" + headers + html;

--- a/src/test/java/HTTPRequestHandlerTest.java
+++ b/src/test/java/HTTPRequestHandlerTest.java
@@ -23,6 +23,21 @@ public class HTTPRequestHandlerTest extends TestCase {
         assertEquals(basicResponse, new String(response, "UTF-8"));
     }
 
+    public void testItReturnsAnIndexIfNotAtRoot() throws Exception {
+        InputStream request = new ByteArrayInputStream("GET /brians HTTP/1.1".getBytes());
+        String[] args = new String[3];
+        args[0] = "-d";
+        args[1] = "public";
+        args[2] = "-ai";
+        Setup settings = new Setup(args);
+        HTTPRequestHandler handler = new HTTPRequestHandler(settings);
+
+        byte[] response = handler.handle(request);
+
+        String basicResponse = basicResponse("Content-Type: text/html\r\n\r\n", wrapHtml("<h1>Brian's cool website</h1>"));
+        assertEquals(basicResponse, new String(response, "UTF-8"));
+    }
+
     public void testItReadsADirectoryStructureIfNoIndexPresent() throws Exception {
         InputStream request = new ByteArrayInputStream("GET / HTTP/1.1".getBytes());
         HTTPRequestHandler handler = new HTTPRequestHandler("public");
@@ -65,7 +80,7 @@ public class HTTPRequestHandlerTest extends TestCase {
         byte[] response = handler.handle(request);
 
         String innerHtml = "" +
-                createLink("", "..") +
+                createLink("/", "..") +
                 createLink("/brians/index.html", "index.html") +
                 createLink("/brians/ping-pong-equipment", "ping-pong-equipment");
         String basicResponse = basicResponse("Content-Type: text/html\r\n\r\n", wrapHtml(innerHtml));
@@ -92,7 +107,7 @@ public class HTTPRequestHandlerTest extends TestCase {
         byte[] response = handler.handle(request);
 
         String innerHtml = "" +
-                createLink("", "..") +
+                createLink("/", "..") +
                 createLink("/games/1", "1") +
                 createLink("/games/2", "2");
         String basicResponse = basicResponse("Content-Type: text/html\r\n\r\n", wrapHtml(innerHtml));
@@ -110,6 +125,20 @@ public class HTTPRequestHandlerTest extends TestCase {
                 createLink("/brians/ping-pong-equipment/lighting", "lighting") +
                 createLink("/brians/ping-pong-equipment/nets", "nets") +
                 createLink("/brians/ping-pong-equipment/paddles", "paddles");
+        String basicResponse = basicResponse("Content-Type: text/html\r\n\r\n", wrapHtml(innerHtml));
+        assertEquals(basicResponse, new String(response, "UTF-8"));
+    }
+
+    public void testUpLinksWorkOneLevelDown() throws Exception {
+        InputStream request = new ByteArrayInputStream("GET /brians HTTP/1.1".getBytes());
+        HTTPRequestHandler handler = new HTTPRequestHandler("public");
+
+        byte[] response = handler.handle(request);
+
+        String innerHtml = "" +
+                createLink("/", "..") +
+                createLink("/brians/index.html", "index.html") +
+                createLink("/brians/ping-pong-equipment", "ping-pong-equipment");
         String basicResponse = basicResponse("Content-Type: text/html\r\n\r\n", wrapHtml(innerHtml));
         assertEquals(basicResponse, new String(response, "UTF-8"));
     }
@@ -185,12 +214,6 @@ public class HTTPRequestHandlerTest extends TestCase {
 
         assertEquals("HTTP/1.1 404 NOT FOUND\r\n\r\n", new String(response, "UTF-8"));
     }
-
-//    public void testItServesUpAnIndexOnDirectoryWhenPassedFlag() throws Exception {
-//        InputStream request = new ByteArrayInputStream("GET / HTTP/1.1".getBytes());
-//        HTTPRequestHandler handler = new HTTPRequestHandler("public", true);
-//
-//    }
 
     private String basicResponse(String headers, String html) {
         return "HTTP/1.1 200 OK\r\n" + headers + html;

--- a/src/test/java/HTTPServerTest.java
+++ b/src/test/java/HTTPServerTest.java
@@ -23,7 +23,9 @@ public class HTTPServerTest extends TestCase {
                 "<!DOCTYPE html><html lang=\"en\"><body><h1>Hello World</h1></body></html>";
         MockSocket socket = new MockSocket(request);
         MockServerSocket serverSocket = new MockServerSocket(socket, -1);
-        Server server = new Server(serverSocket, new String[0]);
+        String[] args = new String[1];
+        args[0] = "-ai";
+        Server server = new Server(serverSocket, args);
 
         server.run();
 

--- a/src/test/java/SetupTest.java
+++ b/src/test/java/SetupTest.java
@@ -1,6 +1,9 @@
 import HTTPServer.Setup;
 import junit.framework.TestCase;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Created by jphoenix on 8/8/16.
  */
@@ -38,5 +41,22 @@ public class SetupTest extends TestCase {
 
         assertEquals("src", setup.root.getName());
         assertEquals(7500, setup.port);
+    }
+
+    public void testItTakesAnAutoIndexFlag() throws Exception {
+        String[] args = new String[1];
+        args[0] = "-ai";
+
+        Setup setup = new Setup(args);
+
+        assertEquals(true, setup.autoIndex);
+    }
+
+    public void testItSetsFalseByDefault() throws Exception {
+        String[] args = new String[0];
+
+        Setup setup = new Setup(args);
+
+        assertEquals(false, setup.autoIndex);
     }
 }


### PR DESCRIPTION
This PR implements a flag for autoIndex.

Now a use can pass in the -ai (autoIndex) flag and it will change the functionality of how the Server reads index.html's.

By default it is turned off (false) which means that if you navigate to a directory it will show the contents of that directory for you to navigate.

If you switch it on (by passing in the -ai flag) then when you navigate to directory with an index.html present it will load that instead.

If you navigate to a directory with no index.html it will load the directory structure either way.

closes #17 
